### PR TITLE
Refactor code windows behavior changer and tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,5 +240,9 @@ _Pvt_Extensions
 .settings
 .project
 
+# Visual Studio Code
+.vscode
+
 # injectorpp
 build/
+

--- a/README.MD
+++ b/README.MD
@@ -5,18 +5,67 @@
 Injector++ is a library to help you fake virtual/non-virtual methods, static methods and global functions **WITHOUT** changing existing code.
 
 ## How to use
-It's extremely easy to mock class methods via Injector++.
 
-### Mock non-virtual methods
+## Prerequisites
 
-Below example fakes BaseClassTest::GetAnInteger() by using FakeFunc():
+### Windows
+- Injector++ only supports x86 Windows by now.
+- Injector++ needs to retrieve information from pdb, therefore please:
+- In Visual Studio, open project property dialog, select Configuration Properties -> Linker -> Debugging, change `Generate Debug Info` to `Debug`.
+- Add `dbgHelp.lib` as dependency in your test project setting.
+- Project property dialog -> Linker -> General -> Enable Incremental Linking -> `No (/INCREMENTAL:NO)`.
+
+### Linux
+In progress.
+
+### Mac OS
+In progress.
+
+## Mock global functions
+
+Below example fakes `fooReturnString` by using `fakeFooReturnString`:
+
+```cpp
+
+std::string fooReturnString()
+{
+    return "FooReturnString";
+}
+
+std::string fakeFooReturnString()
+{
+    return "FakeFooReturnString";
+}
+
+TEST_F(FakeClassNonVirtualMethodTestFixture, FakeGlobalStringFunctionWhenCalled)
+{
+    // Prepare
+    std::string expected = "FakeFooReturnString";
+    InjectorPP::Injector injector;
+
+    injector.whenCalled(fooReturnString)
+        .willExecute(fakeFooReturnString);
+
+    // Act
+    // fakeFooReturnString will be executued!
+    std::string actual = fooReturnString();
+
+    // Assert
+    EXPECT_EQ(expected, actual);
+}
+
+```
+
+## Mock non-virtual methods
+
+Below example fakes `BaseClassTest::getAnInteger()` by using `fakeFunc()`:
 
 ```cpp
 
 class FakeClassNonVirtualMethodTestFixture : public ::testing::Test
 {
 public:
-    int FakeFunc()
+    int fakeFunc()
     {
         return 6;
     }
@@ -28,14 +77,14 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeIntFunctionWhenCalled)
     int expected = 6;
     InjectorPP::Injector injector;
 
-    injector.WhenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::GetAnInteger))
-        .WillExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::FakeFunc));
+    injector.whenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::getAnInteger))
+        .willExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::fakeFunc));
 
     BaseClassTest b = BaseClassTest();
 
     // Act
     // FakeFunc will be executed!
-    int actual = b.GetAnInteger();
+    int actual = b.getAnInteger();
 
     // Assert
     EXPECT_EQ(expected, actual);
@@ -43,7 +92,7 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeIntFunctionWhenCalled)
 
 ```
 
-### Mock virtual methods
+## Mock virtual methods
 Injector++ supports virtual method mocking (Amazing, huh?). Below is a simple example:
 
 ```cpp
@@ -60,12 +109,12 @@ TEST_F(FakeClassVirtualMethodTestFixture, MockDerivedClassVirtualMemberFunctionW
     BaseClassTest* derived = new SubClassTest();
 
     InjectorPP::Injector injector;
-    injector.WhenCalledVirtualMethod(derived, "GetAnIntegerVirtual")
-        .WillExecute(FakeIntFuncForDerived);
+    injector.whenCalledVirtualMethod(derived, "getAnIntegerVirtual")
+        .willExecute(fakeIntFuncForDerived);
 
     // Act
     // FakeIntFuncForDerived() will be exectued!
-    int actual = derived->GetAnIntegerVirtual();
+    int actual = derived->getAnIntegerVirtual();
 
     // Assert
     EXPECT_EQ(expected, actual);
@@ -76,7 +125,7 @@ TEST_F(FakeClassVirtualMethodTestFixture, MockDerivedClassVirtualMemberFunctionW
 
 ```
 
-### Mock static methods
+## Mock static methods
 Injector++ supports static method mocking. Below is a simple example:
 
 ```cpp
@@ -84,8 +133,8 @@ Injector++ supports static method mocking. Below is a simple example:
 Address FakeGetAnAddress()
 {
     Address addr;
-    addr.SetAddressLine("fakeAddressLine");
-    addr.SetZipCode("fakeZipCode");
+    addr.setAddressLine("fakeAddressLine");
+    addr.setZipCode("fakeZipCode");
 
     return addr;
 }
@@ -94,38 +143,23 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeStaticFunctionReturnUserDefined
 {
     // Prepare
     Address expected;
-    expected.SetAddressLine("fakeAddressLine");
-    expected.SetZipCode("fakeZipCode");
+    expected.setAddressLine("fakeAddressLine");
+    expected.setZipCode("fakeZipCode");
 
     InjectorPP::Injector injector;
 
-    injector.WhenCalled(INJECTORPP_STATIC_MEMBER_FUNCTION(BaseClassTest::GetAnAddressStatic))
-        .WillExecute(FakeGetAnAddress);
+    injector.whenCalled(INJECTORPP_STATIC_MEMBER_FUNCTION(BaseClassTest::getAnAddressStatic))
+        .willExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::fakeGetAnAddress));
 
     // Act
     // FakeGetAnAddress will be executed!
-    Address actual = BaseClassTest::GetAnAddressStatic();
+    Address actual = BaseClassTest::getAnAddressStatic();
 
     // Assert
     EXPECT_EQ(expected, actual);
 }
 
 ```
-
-## Prerequisites
-
-### Windows
-- Injector++ only supports x86 Windows by now.
-- Injector++ needs to retrieve information from pdb, therefore please:
-- In Visual Studio, open project property dialog, select Configuration Properties -> Linker -> Debuggin, change Generate Debug Info to `Debug`.
-- Add `dbgHelp.lib` as dependency in your test project setting.
-- Project property dialog -> Linker -> General -> Enable Incremental Linking -> `No (/INCREMENTAL:NO)`.
-
-### Linux
-In progress.
-
-### Mac OS
-In progress.
 
 ## Roadmap
 There's a headache of C++ unit testing - No way to abstract the legacy code. As there's no reflection in C++, it is not that easy to change the behavior of non-virtual and static methods, which makes C++ unit testing extremely hard.
@@ -139,3 +173,32 @@ Injector++ intends to resolve the headache. Its goal is to make static method, n
 
 ## Contribute
 Welcome to help Injector++. You can submit bugs, suggestions and feature requests to the issue tracker, or send me pull request. Happy coding & testing!
+
+### Build the source code
+
+#### Windows
+
+You need following prerequisites:
+- cmake 2.6+
+- Visual Studio 2008+ (Please create an issue if you need older MSVC support)
+
+Run `.\build.cmd` to full build the source code as well as running tests.
+
+Run `.\build.cmd /f` to clean the build directory and rebuild all the source code and running tests.
+
+Run `.\build.cmd /skiptests` if you want build source code without building and running tests.
+
+You can combine `/f` and `/skiptests`:
+
+```sh
+.\build.cmd /f /skiptests
+```
+
+After build finished, you'll find `injectorpp.sln` under `build` folder. You can use Visual Studio to edit and debug the code.
+
+#### Linux
+In progress.
+
+#### Mac OS
+In progress.
+

--- a/README.MD
+++ b/README.MD
@@ -6,22 +6,22 @@ Injector++ is a library to help you fake virtual/non-virtual methods, static met
 
 ## How to use
 
-## Prerequisites
+### Prerequisites
 
-### Windows
+#### Windows
 - Injector++ only supports x86 Windows by now.
 - Injector++ needs to retrieve information from pdb, therefore please:
 - In Visual Studio, open project property dialog, select Configuration Properties -> Linker -> Debugging, change `Generate Debug Info` to `Debug`.
 - Add `dbgHelp.lib` as dependency in your test project setting.
 - Project property dialog -> Linker -> General -> Enable Incremental Linking -> `No (/INCREMENTAL:NO)`.
 
-### Linux
+#### Linux
 In progress.
 
-### Mac OS
+#### Mac OS
 In progress.
 
-## Mock global functions
+### Mock global functions
 
 Below example fakes `fooReturnString` by using `fakeFooReturnString`:
 
@@ -56,7 +56,7 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeGlobalStringFunctionWhenCalled)
 
 ```
 
-## Mock non-virtual methods
+### Mock non-virtual methods
 
 Below example fakes `BaseClassTest::getAnInteger()` by using `fakeFunc()`:
 
@@ -92,7 +92,7 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeIntFunctionWhenCalled)
 
 ```
 
-## Mock virtual methods
+### Mock virtual methods
 Injector++ supports virtual method mocking (Amazing, huh?). Below is a simple example:
 
 ```cpp
@@ -125,7 +125,7 @@ TEST_F(FakeClassVirtualMethodTestFixture, MockDerivedClassVirtualMemberFunctionW
 
 ```
 
-## Mock static methods
+### Mock static methods
 Injector++ supports static method mocking. Below is a simple example:
 
 ```cpp

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,5 @@
 @echo off
+set finalErrorLevel=0
 set skiptests=0
 if not "%~1"=="" (
     if "%~1" == "/f" (
@@ -26,10 +27,31 @@ cd build
 cmake ../
 
 msbuild /nologo /t:injectorpp injectorpp.sln
+if errorlevel 1 (
+    set finalErrorLevel=1
+    goto exit
+)
 
 if not %skiptests% == 1 (
     msbuild /nologo /t:gmock injectorpp.sln
+    if errorlevel 1 (
+        set finalErrorLevel=1
+        goto exit
+    )
+
     msbuild /nologo /t:injectorpp_test injectorpp.sln
+    if errorlevel 1 (
+        set finalErrorLevel=1
+        goto exit
+    )
+
     %~dp0\build\tests\Debug\injectorpp_test.exe
+    if errorlevel 1 (
+        set finalErrorLevel=1
+        goto exit
+    )
 )
+
+:exit
 cd ..
+exit /b %finalErrorLevel%

--- a/src/windows/include/windows/behaviorchanger.h
+++ b/src/windows/include/windows/behaviorchanger.h
@@ -16,9 +16,9 @@ namespace InjectorPP
         virtual ~BehaviorChanger();
 
         // A magic function to change the function behavior at runtime.
-        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType) = 0;
+        virtual void replaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType) = 0;
 
-        virtual void DirectWriteToFunction(ULONG64 funcAddress, const byte* asmCode, size_t asmCodeSize);
+        virtual void directWriteToFunction(ULONG64 funcAddress, const byte* asmCode, size_t asmCodeSize);
     private:
         BehaviorChanger(const BehaviorChanger&);
     };

--- a/src/windows/include/windows/behaviorchanger.h
+++ b/src/windows/include/windows/behaviorchanger.h
@@ -4,6 +4,8 @@
 #include <Windows.h>
 #include <vector>
 #include "originalfuncasm.h"
+#include "functiontype.h"
+#include "functionreturntype.h"
 
 namespace InjectorPP
 {
@@ -13,8 +15,8 @@ namespace InjectorPP
         BehaviorChanger();
         virtual ~BehaviorChanger();
 
-        // A magic function to change the function behavior at runtime
-        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, int functionType, int returnType) = 0;
+        // A magic function to change the function behavior at runtime.
+        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType) = 0;
 
         virtual void DirectWriteToFunction(ULONG64 funcAddress, const byte* asmCode, size_t asmCodeSize);
     private:

--- a/src/windows/include/windows/behaviorchangerfactory.h
+++ b/src/windows/include/windows/behaviorchangerfactory.h
@@ -26,7 +26,7 @@ namespace InjectorPP
     class BehaviorChangerFactory
     {
     public:
-        static BehaviorChanger* Create();
+        static BehaviorChanger* create();
 
     private:
         BehaviorChangerFactory();

--- a/src/windows/include/windows/classresolver.h
+++ b/src/windows/include/windows/classresolver.h
@@ -15,7 +15,7 @@ namespace InjectorPP
 
         virtual ~ClassResolver();
 
-        virtual void ResolveMethods(const ULONG64& modBase, const std::string className, std::vector<Function>& resolvedMethods);
+        virtual void resolveMethods(const ULONG64& modBase, const std::string className, std::vector<Function>& resolvedMethods);
 
     private:
         HANDLE m_hProcess;

--- a/src/windows/include/windows/functionresolver.h
+++ b/src/windows/include/windows/functionresolver.h
@@ -16,34 +16,33 @@ namespace InjectorPP
 
         virtual ~FunctionResolver();
 
-        virtual void Resolve(const ULONG64& modBase, const ULONG& typeIndex, Function& resolvedFunction);
+        virtual void resolve(const ULONG64& modBase, const ULONG& typeIndex, Function& resolvedFunction);
 
-        virtual std::string GetMethodSymbolFromAddress(const ULONG64& funcAddress);
+        virtual std::string getMethodSymbolFromAddress(const ULONG64& funcAddress);
 
-        virtual ResolvedType GetMethodReturnTypeFromAddress(const ULONG64& funcAddress);
+        virtual ResolvedType getMethodReturnTypeFromAddress(const ULONG64& funcAddress);
 
     protected:
         // Resolve the function return type.
-        virtual ResolvedType ResolveReturnType(const ULONG64& modBase, const ULONG& typeIndex);
+        virtual ResolvedType resolveReturnType(const ULONG64& modBase, const ULONG& typeIndex);
 
-        virtual void ResolveParameters(const ULONG64& functionAddress, const ULONG64& modBase, const ULONG& typeIndex, std::vector<FunctionParameter>& resolvedParameters);
+        virtual void resolveParameters(const ULONG64& functionAddress, const ULONG64& modBase, const ULONG& typeIndex, std::vector<FunctionParameter>& resolvedParameters);
     private:
         // Disable copy constructor.
         FunctionResolver(const FunctionResolver&);
 
         // Loads the name of the type of that symbol
-        void LoadType(ULONG64 modBase, ULONG typeIndex, ResolvedType& resolvedType);
+        void loadType(ULONG64 modBase, ULONG typeIndex, ResolvedType& resolvedType);
 
         // Loads a basic type (int, float, char, ...)
-        void LoadBasicType(BasicType bt, ULONG64 byteSize, ResolvedType& resolvedType);
+        void loadBasicType(BasicType bt, ULONG64 byteSize, ResolvedType& resolvedType);
 
         // Loads the type pointed to
-        void LoadPointerType(ULONG64 modBase, ULONG typeIndex, ULONG subType, ResolvedType& resolvedType);
+        void loadPointerType(ULONG64 modBase, ULONG typeIndex, ULONG subType, ResolvedType& resolvedType);
 
+        HANDLE m_hProcess;
         VARIANT m_value;
         std::string m_objName;
-        //std::string m_typeName;
-        HANDLE m_hProcess;
         std::string m_enumValue;
     };
 }

--- a/src/windows/include/windows/functionreturntype.h
+++ b/src/windows/include/windows/functionreturntype.h
@@ -1,0 +1,13 @@
+#ifndef INJECTORPP_FUNCTIONRETURNTYPE_H
+#define INJECTORPP_FUNCTIONRETURNTYPE_H
+
+namespace InjectorPP
+{
+enum FunctionReturnType
+{
+    BasicReturnType,
+    ComplexReturnType
+};
+}
+
+#endif

--- a/src/windows/include/windows/functiontype.h
+++ b/src/windows/include/windows/functiontype.h
@@ -1,0 +1,15 @@
+#ifndef INJECTORPP_FUNCTIONTYPE_H
+#define INJECTORPP_FUNCTIONTYPE_H
+
+namespace InjectorPP
+{
+    enum FunctionType
+    {
+        GlobalFunction,
+        NonVirtualMemberFunction,
+        VirtualMemberFunction,
+        StaticMemberFunction
+    };
+}
+
+#endif

--- a/src/windows/include/windows/iclassresolver.h
+++ b/src/windows/include/windows/iclassresolver.h
@@ -9,7 +9,7 @@ namespace InjectorPP
     class IClassResolver
     {
     public:
-        virtual void ResolveMethods(const ULONG64& modBase, const std::string className, std::vector<Function>& resolvedMethods) = 0;
+        virtual void resolveMethods(const ULONG64& modBase, const std::string className, std::vector<Function>& resolvedMethods) = 0;
     };
 }
 

--- a/src/windows/include/windows/ifunctionresolver.h
+++ b/src/windows/include/windows/ifunctionresolver.h
@@ -11,9 +11,9 @@ namespace InjectorPP
     class IFunctionResolver
     {
     public:
-        virtual std::string GetMethodSymbolFromAddress(const ULONG64& funcAddress) = 0;
-        virtual ResolvedType GetMethodReturnTypeFromAddress(const ULONG64& funcAddress) = 0;
-        virtual void Resolve(const ULONG64& modBase, const ULONG& typeIndex, Function& resolvedFunction) = 0;
+        virtual std::string getMethodSymbolFromAddress(const ULONG64& funcAddress) = 0;
+        virtual ResolvedType getMethodReturnTypeFromAddress(const ULONG64& funcAddress) = 0;
+        virtual void resolve(const ULONG64& modBase, const ULONG& typeIndex, Function& resolvedFunction) = 0;
     };
 }
 

--- a/src/windows/include/windows/injector.h
+++ b/src/windows/include/windows/injector.h
@@ -23,7 +23,7 @@ namespace InjectorPP
             :m_injectorCore(NULL)
         {
             this->m_injectorCore = new InjectorCore();
-            this->m_injectorCore->Initialize();
+            this->m_injectorCore->initialize();
         }
 
         virtual ~Injector()
@@ -45,7 +45,7 @@ namespace InjectorPP
             }
         }
 
-        Injector& WhenCalled(void* srcMockFunc, bool isMemberFunction = false, bool isStaticMemberFunction = false)
+        Injector& whenCalled(void* srcMockFunc, bool isMemberFunction = false, bool isStaticMemberFunction = false)
         {
             FunctionWrapper* functionWrapper = new FunctionWrapper();
             functionWrapper->functionAddress = srcMockFunc;
@@ -58,9 +58,9 @@ namespace InjectorPP
             return *this;
         }
 
-        Injector& WhenCalledVirtualMethod(void* classInstance, const std::string& virtualMethodName)
+        Injector& whenCalledVirtualMethod(void* classInstance, const std::string& virtualMethodName)
         {
-            void* virtualFunction = this->m_injectorCore->GetVirtualMethodAddress(classInstance, virtualMethodName);
+            void* virtualFunction = this->m_injectorCore->getVirtualMethodAddress(classInstance, virtualMethodName);
 
             FunctionWrapper* functionWrapper = new FunctionWrapper();
             functionWrapper->functionAddress = virtualFunction;
@@ -73,7 +73,7 @@ namespace InjectorPP
             return *this;
         }
 
-        Injector& WillExecute(void* destMockFunc, bool isMemberFunction = false, bool isStaticMemberFunction = false)
+        Injector& willExecute(void* destMockFunc, bool isMemberFunction = false, bool isStaticMemberFunction = false)
         {
             if (this->m_whenCalledFunc.empty())
             {
@@ -88,7 +88,7 @@ namespace InjectorPP
             FunctionWrapper* srcFunctionWrapper = this->m_whenCalledFunc.top();
             this->m_whenCalledFunc.pop();
 
-            this->m_injectorCore->ReplaceFunction(srcFunctionWrapper->functionAddress,
+            this->m_injectorCore->replaceFunction(srcFunctionWrapper->functionAddress,
                 destMockFunc,
                 srcFunctionWrapper->isMemberFunction,
                 srcFunctionWrapper->isStaticMemberFunction,

--- a/src/windows/include/windows/injectorcore.h
+++ b/src/windows/include/windows/injectorcore.h
@@ -22,18 +22,18 @@ namespace InjectorPP
 
         virtual ~InjectorCore();
 
-        void Initialize();
+        void initialize();
 
-        void* GetVirtualMethodAddress(void* classInstance, const std::string& virtualMethodName);
+        void* getVirtualMethodAddress(void* classInstance, const std::string& virtualMethodName);
 
-        void ReplaceFunction(void* srcFunc, void* destFunc, bool isSourceMemberFunction, bool isSourceStaticMemberFunction, bool isSourceVirtualMemberFunction);
+        void replaceFunction(void* srcFunc, void* destFunc, bool isSourceMemberFunction, bool isSourceStaticMemberFunction, bool isSourceVirtualMemberFunction);
 
     private:
         InjectorCore(const InjectorCore&);
 
-        void RecoverAllReplacedFunctions();
+        void recoverAllReplacedFunctions();
 
-        bool SaveOriginalFuncASM(OriginalFuncASM* originalFuncASM);
+        bool saveOriginalFuncASM(OriginalFuncASM* originalFuncASM);
 
         std::vector<void*> m_allocatedTypeInstances;
 

--- a/src/windows/include/windows/symbolinfohelper.h
+++ b/src/windows/include/windows/symbolinfohelper.h
@@ -16,7 +16,7 @@ namespace InjectorPP
 
         ~SymbolInfoHelper();
 
-        PSYMBOL_INFO AllocSymbol(int nameLen = MAX_SYM_NAME);
+        PSYMBOL_INFO allocSymbol(int nameLen = MAX_SYM_NAME);
 
     private:
         SymbolInfoHelper(const SymbolInfoHelper&);

--- a/src/windows/include/windows/utility.h
+++ b/src/windows/include/windows/utility.h
@@ -9,10 +9,10 @@ namespace InjectorPP
     class Utility
     {
     public:
-        static std::string GetLastErrorStdStr();
-        static std::string W2M(const wchar_t* str);
-        static std::vector<std::string>& Split(const std::string &s, char delim, std::vector<std::string> &elems);
-        static std::vector<std::string> Split(const std::string &s, char delim);
+        static std::string getLastErrorStdStr();
+        static std::string w2m(const wchar_t* str);
+        static std::vector<std::string>& split(const std::string &s, char delim, std::vector<std::string> &elems);
+        static std::vector<std::string> split(const std::string &s, char delim);
     private:
         Utility();
         ~Utility();

--- a/src/windows/include/windows/x64windowsbehaviorchanger.h
+++ b/src/windows/include/windows/x64windowsbehaviorchanger.h
@@ -11,7 +11,7 @@ namespace InjectorPP
         X64WindowsBehaviorChanger();
         virtual ~X64WindowsBehaviorChanger();
 
-        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType);
+        virtual void replaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType);
 
     private:
         X64WindowsBehaviorChanger(const X64WindowsBehaviorChanger&);

--- a/src/windows/include/windows/x64windowsbehaviorchanger.h
+++ b/src/windows/include/windows/x64windowsbehaviorchanger.h
@@ -11,7 +11,7 @@ namespace InjectorPP
         X64WindowsBehaviorChanger();
         virtual ~X64WindowsBehaviorChanger();
 
-        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, int functionType, int returnType);
+        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType);
 
     private:
         X64WindowsBehaviorChanger(const X64WindowsBehaviorChanger&);

--- a/src/windows/include/windows/x86windowsbehaviorchanger.h
+++ b/src/windows/include/windows/x86windowsbehaviorchanger.h
@@ -11,7 +11,7 @@ namespace InjectorPP
         X86WindowsBehaviorChanger();
         virtual ~X86WindowsBehaviorChanger();
 
-        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType);
+        virtual void replaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType);
 
     private:
         X86WindowsBehaviorChanger(const X86WindowsBehaviorChanger&);

--- a/src/windows/include/windows/x86windowsbehaviorchanger.h
+++ b/src/windows/include/windows/x86windowsbehaviorchanger.h
@@ -11,7 +11,7 @@ namespace InjectorPP
         X86WindowsBehaviorChanger();
         virtual ~X86WindowsBehaviorChanger();
 
-        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, int functionType, int returnType);
+        virtual void ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType);
 
     private:
         X86WindowsBehaviorChanger(const X86WindowsBehaviorChanger&);

--- a/src/windows/src/behaviorchanger.cpp
+++ b/src/windows/src/behaviorchanger.cpp
@@ -13,7 +13,7 @@ namespace InjectorPP
     {
     }
 
-    void BehaviorChanger::DirectWriteToFunction(ULONG64 funcAddress, const byte* asmCode, size_t asmCodeSize)
+    void BehaviorChanger::directWriteToFunction(ULONG64 funcAddress, const byte* asmCode, size_t asmCodeSize)
     {
         WriteProcessMemory((HANDLE)-1, (void*)funcAddress, asmCode, asmCodeSize, 0);
     }

--- a/src/windows/src/behaviorchangerfactory.cpp
+++ b/src/windows/src/behaviorchangerfactory.cpp
@@ -14,7 +14,7 @@ namespace InjectorPP
     {
     }
 
-    BehaviorChanger* BehaviorChangerFactory::Create()
+    BehaviorChanger* BehaviorChangerFactory::create()
     {
 #ifdef WINENVIRONMENT32
         return new X86WindowsBehaviorChanger();

--- a/src/windows/src/classresolver.cpp
+++ b/src/windows/src/classresolver.cpp
@@ -26,9 +26,9 @@ namespace InjectorPP
         }
     }
 
-    void ClassResolver::ResolveMethods(const ULONG64& modBase, const std::string className, std::vector<Function>& resolvedMethods)
+    void ClassResolver::resolveMethods(const ULONG64& modBase, const std::string className, std::vector<Function>& resolvedMethods)
     {
-        PSYMBOL_INFO classSymbol = this->m_symbolInfoHelper->AllocSymbol();
+        PSYMBOL_INFO classSymbol = this->m_symbolInfoHelper->allocSymbol();
 
         // Retrieve class symbol.
         if (SymGetTypeFromName(this->m_hProcess, modBase, className.c_str(), classSymbol) == FALSE)
@@ -73,7 +73,7 @@ namespace InjectorPP
 
             // Resolve function.
             Function resolvedFunction;
-            this->m_functionResolver->Resolve(classSymbol->ModBase, curChild, resolvedFunction);
+            this->m_functionResolver->resolve(classSymbol->ModBase, curChild, resolvedFunction);
 
             // Add the resolved function to the output.
             resolvedMethods.push_back(resolvedFunction);

--- a/src/windows/src/injectorcore.cpp
+++ b/src/windows/src/injectorcore.cpp
@@ -19,7 +19,7 @@ InjectorCore::InjectorCore()
       m_currentProcessHandler(NULL)
 {
     this->m_currentProcessHandler = GetCurrentProcess();
-    this->m_behaviorChanger = BehaviorChangerFactory::Create();
+    this->m_behaviorChanger = BehaviorChangerFactory::create();
     this->m_functionResolver = new FunctionResolver(this->m_currentProcessHandler);
     this->m_classResolver = new ClassResolver(this->m_currentProcessHandler, this->m_functionResolver);
     this->m_symbolInfoHelper = new SymbolInfoHelper();
@@ -50,7 +50,7 @@ InjectorCore::~InjectorCore()
     }
 
     // Release all original function asms and recover the replaced functions.
-    this->RecoverAllReplacedFunctions();
+    this->recoverAllReplacedFunctions();
 
     if (this->m_symbolInfoHelper != NULL)
     {
@@ -77,7 +77,7 @@ InjectorCore::~InjectorCore()
     }
 }
 
-void InjectorCore::Initialize()
+void InjectorCore::initialize()
 {
     if (!InjectorCore::m_isSymInitialized)
     {
@@ -91,7 +91,7 @@ void InjectorCore::Initialize()
     }
 }
 
-void *InjectorCore::GetVirtualMethodAddress(void *classInstance, const std::string &virtualMethodName)
+void *InjectorCore::getVirtualMethodAddress(void *classInstance, const std::string &virtualMethodName)
 {
     void *result = NULL;
 
@@ -104,7 +104,7 @@ void *InjectorCore::GetVirtualMethodAddress(void *classInstance, const std::stri
     while (*virtualMethodAddress != NULL)
     {
         ULONG64 address = (ULONG64)*virtualMethodAddress;
-        std::string funcSymName = this->m_functionResolver->GetMethodSymbolFromAddress(address);
+        std::string funcSymName = this->m_functionResolver->getMethodSymbolFromAddress(address);
 
         // Is this function symbol name contains the virtual method name?
         if (funcSymName.find(decoratedMethodName) != std::string::npos || funcSymName.find("::" + virtualMethodName) != std::string::npos)
@@ -126,10 +126,10 @@ void *InjectorCore::GetVirtualMethodAddress(void *classInstance, const std::stri
     return result;
 }
 
-void InjectorCore::ReplaceFunction(void *srcFunc, void *destFunc, bool isSourceMemberFunction, bool isSourceStaticMemberFunction, bool isSourceVirtualMemberFunction)
+void InjectorCore::replaceFunction(void *srcFunc, void *destFunc, bool isSourceMemberFunction, bool isSourceStaticMemberFunction, bool isSourceVirtualMemberFunction)
 {
     bool isComplexReturn = false;
-    ResolvedType returnType = this->m_functionResolver->GetMethodReturnTypeFromAddress((ULONG64)srcFunc);
+    ResolvedType returnType = this->m_functionResolver->getMethodReturnTypeFromAddress((ULONG64)srcFunc);
     if (returnType.SymbolTag != SymTagEnum::SymTagBaseType && returnType.SymbolTag != SymTagEnum::SymTagPointerType)
     {
         isComplexReturn = true;
@@ -153,16 +153,16 @@ void InjectorCore::ReplaceFunction(void *srcFunc, void *destFunc, bool isSourceM
     }
     FunctionReturnType functionReturnType = isComplexReturn ? FunctionReturnType::ComplexReturnType : FunctionReturnType::BasicReturnType;
 
-    this->m_behaviorChanger->ReplaceFunction((ULONG64)srcFunc, (ULONG64)destFunc, originalFuncAsm, functionType, functionReturnType);
+    this->m_behaviorChanger->replaceFunction((ULONG64)srcFunc, (ULONG64)destFunc, originalFuncAsm, functionType, functionReturnType);
 
-    if (!this->SaveOriginalFuncASM(originalFuncAsm))
+    if (!this->saveOriginalFuncASM(originalFuncAsm))
     {
         delete originalFuncAsm;
         originalFuncAsm = NULL;
     }
 }
 
-void InjectorCore::RecoverAllReplacedFunctions()
+void InjectorCore::recoverAllReplacedFunctions()
 {
     // Release all original function asms.
     std::vector<OriginalFuncASM *>::iterator ofaIt;
@@ -171,7 +171,7 @@ void InjectorCore::RecoverAllReplacedFunctions()
         if (*ofaIt != NULL)
         {
             // Recover the original function behavior.
-            this->m_behaviorChanger->DirectWriteToFunction((*ofaIt)->funcAddress, (*ofaIt)->asmCode, 6);
+            this->m_behaviorChanger->directWriteToFunction((*ofaIt)->funcAddress, (*ofaIt)->asmCode, 6);
 
             delete *ofaIt;
             *ofaIt = NULL;
@@ -181,7 +181,7 @@ void InjectorCore::RecoverAllReplacedFunctions()
     this->m_originalFunctionASMVector.clear();
 }
 
-bool InjectorCore::SaveOriginalFuncASM(OriginalFuncASM *originalFuncASM)
+bool InjectorCore::saveOriginalFuncASM(OriginalFuncASM *originalFuncASM)
 {
     if (originalFuncASM->funcAddress == 0)
     {

--- a/src/windows/src/injectorcore.cpp
+++ b/src/windows/src/injectorcore.cpp
@@ -9,209 +9,197 @@
 
 namespace InjectorPP
 {
-    bool InjectorCore::m_isSymInitialized = false;
+bool InjectorCore::m_isSymInitialized = false;
 
-    InjectorCore::InjectorCore()
-        :m_behaviorChanger(NULL),
-        m_classResolver(NULL),
-        m_functionResolver(NULL),
-        m_symbolInfoHelper(NULL),
-        m_currentProcessHandler(NULL)
+InjectorCore::InjectorCore()
+    : m_behaviorChanger(NULL),
+      m_classResolver(NULL),
+      m_functionResolver(NULL),
+      m_symbolInfoHelper(NULL),
+      m_currentProcessHandler(NULL)
+{
+    this->m_currentProcessHandler = GetCurrentProcess();
+    this->m_behaviorChanger = BehaviorChangerFactory::Create();
+    this->m_functionResolver = new FunctionResolver(this->m_currentProcessHandler);
+    this->m_classResolver = new ClassResolver(this->m_currentProcessHandler, this->m_functionResolver);
+    this->m_symbolInfoHelper = new SymbolInfoHelper();
+}
+
+InjectorCore::~InjectorCore()
+{
+    // Release all allocated type instances.
+    std::vector<void *>::iterator it;
+    for (it = this->m_allocatedTypeInstances.begin(); it != this->m_allocatedTypeInstances.end(); ++it)
     {
-        this->m_currentProcessHandler = GetCurrentProcess();
-        this->m_behaviorChanger = BehaviorChangerFactory::Create();
-        this->m_functionResolver = new FunctionResolver(this->m_currentProcessHandler);
-        this->m_classResolver = new ClassResolver(this->m_currentProcessHandler, this->m_functionResolver);
-        this->m_symbolInfoHelper = new SymbolInfoHelper();
-    }
-
-    InjectorCore::~InjectorCore()
-    {
-        // Release all allocated type instances.
-        std::vector<void*>::iterator it;
-        for (it = this->m_allocatedTypeInstances.begin(); it != this->m_allocatedTypeInstances.end(); ++it)
+        if (*it != NULL)
         {
-            if (*it != NULL)
-            {
-                delete *it;
-                *it = NULL;
-            }
-        }
-
-        // Release all fake classes.
-        std::vector<Class*>::iterator classIt;
-        for (classIt = this->m_resolvedClasses.begin(); classIt != this->m_resolvedClasses.end(); ++classIt)
-        {
-            if (*classIt != NULL)
-            {
-                delete *classIt;
-                *classIt = NULL;
-            }
-        }
-
-        // Release all original function asms and recover the replaced functions.
-        this->RecoverAllReplacedFunctions();
-
-        if (this->m_symbolInfoHelper != NULL)
-        {
-            delete this->m_symbolInfoHelper;
-            this->m_symbolInfoHelper = NULL;
-        }
-
-        if (this->m_classResolver != NULL)
-        {
-            delete this->m_classResolver;
-            this->m_classResolver = NULL;
-        }
-
-        if (this->m_functionResolver != NULL)
-        {
-            delete this->m_functionResolver;
-            this->m_functionResolver = NULL;
-        }
-
-        if (this->m_behaviorChanger != NULL)
-        {
-            delete m_behaviorChanger;
-            m_behaviorChanger = NULL;
+            delete *it;
+            *it = NULL;
         }
     }
 
-    void InjectorCore::Initialize()
+    // Release all fake classes.
+    std::vector<Class *>::iterator classIt;
+    for (classIt = this->m_resolvedClasses.begin(); classIt != this->m_resolvedClasses.end(); ++classIt)
     {
-        if (!InjectorCore::m_isSymInitialized)
+        if (*classIt != NULL)
         {
-            // Let's initialize the whole symbol system.
-            if (SymInitialize(this->m_currentProcessHandler, NULL, TRUE) == FALSE)
-            {
-                throw;
-            }
-
-            InjectorCore::m_isSymInitialized = true;
+            delete *classIt;
+            *classIt = NULL;
         }
     }
 
-    void* InjectorCore::GetVirtualMethodAddress(void* classInstance, const std::string& virtualMethodName)
+    // Release all original function asms and recover the replaced functions.
+    this->RecoverAllReplacedFunctions();
+
+    if (this->m_symbolInfoHelper != NULL)
     {
-        void* result = NULL;
+        delete this->m_symbolInfoHelper;
+        this->m_symbolInfoHelper = NULL;
+    }
 
-        // The method name stored in pdb may be decorated. We should decorate our
-        // virtual method name either.
-        std::string decoratedMethodName = "?" + virtualMethodName + "@";
+    if (this->m_classResolver != NULL)
+    {
+        delete this->m_classResolver;
+        this->m_classResolver = NULL;
+    }
 
-        ULONG64* vptrForClass = *(ULONG64**)*(ULONG64**)&classInstance;
-        ULONG64** virtualMethodAddress = (ULONG64**)vptrForClass;
-        while (*virtualMethodAddress != NULL)
-        {
-            ULONG64 address = (ULONG64)*virtualMethodAddress;
-            std::string funcSymName = this->m_functionResolver->GetMethodSymbolFromAddress(address);
+    if (this->m_functionResolver != NULL)
+    {
+        delete this->m_functionResolver;
+        this->m_functionResolver = NULL;
+    }
 
-            // Is this function symbol name contains the virtual method name?
-            if (funcSymName.find(decoratedMethodName) != std::string::npos
-                || funcSymName.find("::" + virtualMethodName) != std::string::npos)
-            {
-                // Yes! We found the virtual method address!
-                result = *virtualMethodAddress;
+    if (this->m_behaviorChanger != NULL)
+    {
+        delete m_behaviorChanger;
+        m_behaviorChanger = NULL;
+    }
+}
 
-                break;
-            }
-
-            virtualMethodAddress += 1;
-        }
-
-        if (result == NULL)
+void InjectorCore::Initialize()
+{
+    if (!InjectorCore::m_isSymInitialized)
+    {
+        // Let's initialize the whole symbol system.
+        if (SymInitialize(this->m_currentProcessHandler, NULL, TRUE) == FALSE)
         {
             throw;
         }
 
-        return result;
+        InjectorCore::m_isSymInitialized = true;
+    }
+}
+
+void *InjectorCore::GetVirtualMethodAddress(void *classInstance, const std::string &virtualMethodName)
+{
+    void *result = NULL;
+
+    // The method name stored in pdb may be decorated. We should decorate our
+    // virtual method name either.
+    std::string decoratedMethodName = "?" + virtualMethodName + "@";
+
+    ULONG64 *vptrForClass = *(ULONG64 **)*(ULONG64 **)&classInstance;
+    ULONG64 **virtualMethodAddress = (ULONG64 **)vptrForClass;
+    while (*virtualMethodAddress != NULL)
+    {
+        ULONG64 address = (ULONG64)*virtualMethodAddress;
+        std::string funcSymName = this->m_functionResolver->GetMethodSymbolFromAddress(address);
+
+        // Is this function symbol name contains the virtual method name?
+        if (funcSymName.find(decoratedMethodName) != std::string::npos || funcSymName.find("::" + virtualMethodName) != std::string::npos)
+        {
+            // Yes! We found the virtual method address!
+            result = *virtualMethodAddress;
+
+            break;
+        }
+
+        virtualMethodAddress += 1;
     }
 
-    void InjectorCore::ReplaceFunction(void* srcFunc, void* destFunc, bool isSourceMemberFunction, bool isSourceStaticMemberFunction, bool isSourceVirtualMemberFunction)
+    if (result == NULL)
     {
-        bool isComplexReturn = false;
-		ResolvedType returnType = this->m_functionResolver->GetMethodReturnTypeFromAddress((ULONG64)srcFunc);
-		if (returnType.SymbolTag != SymTagEnum::SymTagBaseType
-			&& returnType.SymbolTag != SymTagEnum::SymTagPointerType)
-		{
-			isComplexReturn = true;
-		}
+        throw;
+    }
 
-        /*if (isSourceMemberFunction && !isSourceStaticMemberFunction)
+    return result;
+}
+
+void InjectorCore::ReplaceFunction(void *srcFunc, void *destFunc, bool isSourceMemberFunction, bool isSourceStaticMemberFunction, bool isSourceVirtualMemberFunction)
+{
+    bool isComplexReturn = false;
+    ResolvedType returnType = this->m_functionResolver->GetMethodReturnTypeFromAddress((ULONG64)srcFunc);
+    if (returnType.SymbolTag != SymTagEnum::SymTagBaseType && returnType.SymbolTag != SymTagEnum::SymTagPointerType)
+    {
+        isComplexReturn = true;
+    }
+
+    // Save the original asm code.
+    // Useful when we recover the function behavior.
+    OriginalFuncASM *originalFuncAsm = new OriginalFuncASM();
+
+    FunctionType functionType = FunctionType::GlobalFunction;
+    if (isSourceMemberFunction)
+    {
+        if (isSourceStaticMemberFunction)
         {
-            ResolvedType returnType = this->m_functionResolver->GetMethodReturnTypeFromAddress((ULONG64)srcFunc);
-            if (returnType.SymbolTag != SymTagEnum::SymTagBaseType
-                && returnType.SymbolTag != SymTagEnum::SymTagPointerType)
-            {
-                isComplexReturn = true;
-            }
-        }*/
-
-        // Save the original asm code. 
-        // Useful when we recover the function behavior.
-        OriginalFuncASM* originalFuncAsm = new OriginalFuncASM();
-
-		int functionType = 0;
-		if (isSourceMemberFunction)
-		{
-			if (isSourceStaticMemberFunction)
-			{
-				functionType = 3;
-			}
-			else
-			{
-				functionType = isSourceVirtualMemberFunction ? 2 : 1;
-			}
-		}
-		int functionReturnType = isComplexReturn ? 1 : 0;
-
-        this->m_behaviorChanger->ReplaceFunction((ULONG64)srcFunc, (ULONG64)destFunc, originalFuncAsm, functionType, functionReturnType);
-
-        if (!this->SaveOriginalFuncASM(originalFuncAsm))
+            functionType = FunctionType::StaticMemberFunction;
+        }
+        else
         {
-            delete originalFuncAsm;
-            originalFuncAsm = NULL;
+            functionType = isSourceVirtualMemberFunction ? FunctionType::VirtualMemberFunction : FunctionType::NonVirtualMemberFunction;
+        }
+    }
+    FunctionReturnType functionReturnType = isComplexReturn ? FunctionReturnType::ComplexReturnType : FunctionReturnType::BasicReturnType;
+
+    this->m_behaviorChanger->ReplaceFunction((ULONG64)srcFunc, (ULONG64)destFunc, originalFuncAsm, functionType, functionReturnType);
+
+    if (!this->SaveOriginalFuncASM(originalFuncAsm))
+    {
+        delete originalFuncAsm;
+        originalFuncAsm = NULL;
+    }
+}
+
+void InjectorCore::RecoverAllReplacedFunctions()
+{
+    // Release all original function asms.
+    std::vector<OriginalFuncASM *>::iterator ofaIt;
+    for (ofaIt = this->m_originalFunctionASMVector.begin(); ofaIt != this->m_originalFunctionASMVector.end(); ++ofaIt)
+    {
+        if (*ofaIt != NULL)
+        {
+            // Recover the original function behavior.
+            this->m_behaviorChanger->DirectWriteToFunction((*ofaIt)->funcAddress, (*ofaIt)->asmCode, 6);
+
+            delete *ofaIt;
+            *ofaIt = NULL;
         }
     }
 
-    void InjectorCore::RecoverAllReplacedFunctions()
+    this->m_originalFunctionASMVector.clear();
+}
+
+bool InjectorCore::SaveOriginalFuncASM(OriginalFuncASM *originalFuncASM)
+{
+    if (originalFuncASM->funcAddress == 0)
     {
-        // Release all original function asms.
-        std::vector<OriginalFuncASM*>::iterator ofaIt;
-        for (ofaIt = this->m_originalFunctionASMVector.begin(); ofaIt != this->m_originalFunctionASMVector.end(); ++ofaIt)
-        {
-            if (*ofaIt != NULL)
-            {
-                // Recover the original function behavior.
-                this->m_behaviorChanger->DirectWriteToFunction((*ofaIt)->funcAddress, (*ofaIt)->asmCode, 6);
-
-                delete *ofaIt;
-                *ofaIt = NULL;
-            }
-        }
-
-        this->m_originalFunctionASMVector.clear();
+        return false;
     }
 
-    bool InjectorCore::SaveOriginalFuncASM(OriginalFuncASM* originalFuncASM)
+    std::vector<OriginalFuncASM *>::iterator it = this->m_originalFunctionASMVector.begin();
+    for (; it != this->m_originalFunctionASMVector.end(); ++it)
     {
-        if (originalFuncASM->funcAddress == 0)
+        if ((*it)->funcAddress == originalFuncASM->funcAddress)
         {
+            // The original asm already been stored.
             return false;
         }
-
-        std::vector<OriginalFuncASM*>::iterator it = this->m_originalFunctionASMVector.begin();
-        for (; it != this->m_originalFunctionASMVector.end(); ++it)
-        {
-            if ((*it)->funcAddress == originalFuncASM->funcAddress)
-            {
-                // The original asm already been stored.
-                return false;
-            }
-        }
-
-        this->m_originalFunctionASMVector.push_back(originalFuncASM);
-
-        return true;
     }
+
+    this->m_originalFunctionASMVector.push_back(originalFuncASM);
+
+    return true;
+}
 }

--- a/src/windows/src/symbolinfohelper.cpp
+++ b/src/windows/src/symbolinfohelper.cpp
@@ -21,7 +21,7 @@ namespace InjectorPP
         }
     }
 
-    PSYMBOL_INFO SymbolInfoHelper::AllocSymbol(int nameLen)
+    PSYMBOL_INFO SymbolInfoHelper::allocSymbol(int nameLen)
     {
         void* space = malloc(sizeof(SYMBOL_INFO) + nameLen);
         memset(space, 0, sizeof(SYMBOL_INFO) + nameLen);

--- a/src/windows/src/utility.cpp
+++ b/src/windows/src/utility.cpp
@@ -13,7 +13,7 @@ namespace InjectorPP
     {
     }
 
-    std::string Utility::GetLastErrorStdStr()
+    std::string Utility::getLastErrorStdStr()
     {
         DWORD error = GetLastError();
         if (error)
@@ -42,7 +42,7 @@ namespace InjectorPP
         return std::string();
     }
 
-    std::string Utility::W2M(const wchar_t* str)
+    std::string Utility::w2m(const wchar_t* str)
     {
         int muLen = WideCharToMultiByte(CP_ACP, 0, str, -1, NULL, 0, NULL, NULL);
         if (muLen == 0)
@@ -64,7 +64,7 @@ namespace InjectorPP
         return temp;
     }
 
-    std::vector<std::string>& Utility::Split(const std::string &s, char delim, std::vector<std::string> &elems)
+    std::vector<std::string>& Utility::split(const std::string &s, char delim, std::vector<std::string> &elems)
     {
         std::stringstream ss(s);
         std::string item;
@@ -77,10 +77,10 @@ namespace InjectorPP
     }
 
 
-    std::vector<std::string> Utility::Split(const std::string &s, char delim)
+    std::vector<std::string> Utility::split(const std::string &s, char delim)
     {
         std::vector<std::string> elems;
-        Utility::Split(s, delim, elems);
+        Utility::split(s, delim, elems);
 
         return elems;
     }

--- a/src/windows/src/x64windowsbehaviorchanger.cpp
+++ b/src/windows/src/x64windowsbehaviorchanger.cpp
@@ -15,7 +15,7 @@ namespace InjectorPP
     {
     }
 
-    void X64WindowsBehaviorChanger::ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType)
+    void X64WindowsBehaviorChanger::replaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType)
     {
         throw std::logic_error("Not supported yet.");
     }

--- a/src/windows/src/x64windowsbehaviorchanger.cpp
+++ b/src/windows/src/x64windowsbehaviorchanger.cpp
@@ -15,7 +15,7 @@ namespace InjectorPP
     {
     }
 
-    void X64WindowsBehaviorChanger::ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, int functionType, int returnType)
+    void X64WindowsBehaviorChanger::ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, FunctionType functionType, FunctionReturnType returnType)
     {
         throw std::logic_error("Not supported yet.");
     }

--- a/src/windows/src/x86windowsbehaviorchanger.cpp
+++ b/src/windows/src/x86windowsbehaviorchanger.cpp
@@ -6,211 +6,238 @@ using std::vector;
 
 namespace InjectorPP
 {
-    X86WindowsBehaviorChanger::X86WindowsBehaviorChanger()
+X86WindowsBehaviorChanger::X86WindowsBehaviorChanger()
+{
+}
+
+X86WindowsBehaviorChanger::~X86WindowsBehaviorChanger()
+{
+}
+
+void X86WindowsBehaviorChanger::ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM *originalFuncAsm, FunctionType functionType, FunctionReturnType returnType)
+{
+    // The idea is hijack the original function, inject op codes to let it 
+    // jump to the target function.
+    // Here we need to handle several kind of functions.
+    //
+    // 1. Function returns basic type:
+    // For instance: int BaseClassTest::GetAnInteger(); 
+    // We want to change the body of this function to:
+    // {
+    //      return targetFunction();   
+    // }
+    // MSVC will generate following asm code. We just need to inject the same
+    // code to original function. Note we can minimize the code from eliminating
+    // 00B811D4~00B811DB and _RTC_CheckEsp.
+    // 
+    // 00B811D0 55                   push        ebp  
+    // 00B811D1 8B EC                mov         ebp,esp  
+    // 00B811D3 51                   push        ecx  
+    // 00B811D4 C7 45 FC CC CC CC CC mov         dword ptr [this],0CCCCCCCCh  
+    // 00B811DB 89 4D FC             mov         dword ptr [this],ecx  
+    //    return targetFunction();
+    // 00B811DE E8 B0 C4 FD FF       call        targetFunction (0B5D693h)  
+    // }
+    // 00B811E3 83 C4 04             add         esp,4  
+    // 00B811E6 3B EC                cmp         ebp,esp  
+    // 00B811E8 E8 6C 40 FD FF       call        __RTC_CheckEsp (0B55259h)  
+    // 00B811ED 8B E5                mov         esp,ebp  
+    // 00B811EF 5D                   pop         ebp  
+    // 00B811F0 C3                   ret
+    //
+    // 2. Non-static member function return complex type.
+    // 002C0220 55                   push        ebp  
+    // 002C0221 8B EC                mov         ebp,esp  
+    // 002C0223 83 EC 08             sub         esp,8  
+    // 002C0226 C7 45 F8 CC CC CC CC mov         dword ptr [ebp-8],0CCCCCCCCh  
+    // 002C022D C7 45 FC CC CC CC CC mov         dword ptr [this],0CCCCCCCCh  
+    // 002C0234 89 4D FC             mov         dword ptr [this],ecx  
+    // 002C0237 C7 45 F8 00 00 00 00 mov         dword ptr [ebp-8],0  
+    //    return targetFunction();
+    // 002C023E 8B 45 08             mov         eax,dword ptr [ebp+8]  
+    // 002C0241 50                   push        eax  
+    // 002C0242 E8 D4 D3 FD FF       call        targetFunction (029D61Bh)  
+    // 002C0247 83 C4 04             add         esp,4  
+    // 002C024A 8B 4D F8             mov         ecx,dword ptr [ebp-8]  
+    // 002C024D 83 C9 01             or          ecx,1  
+    // 002C0250 89 4D F8             mov         dword ptr [ebp-8],ecx  
+    // 002C0253 8B 45 08             mov         eax,dword ptr [ebp+8]  
+    // }
+    // 002C0256 83 C4 08             add         esp,8  
+    // 002C0259 3B EC                cmp         ebp,esp  
+    // 002C025B E8 26 50 FD FF       call        __RTC_CheckEsp (0295286h)  
+    // 002C0260 8B E5                mov         esp,ebp  
+    // 002C0262 5D                   pop         ebp  
+    // 002C0263 C2 04 00             ret         4  
+    //
+    // 3. Static member function return complex type.
+    // 011B31F0 55                   push        ebp  
+    // 011B31F1 8B EC                mov         ebp,esp  
+    // 011B31F3 51                   push        ecx  
+    // 011B31F4 C7 45 FC CC CC CC CC mov         dword ptr [ebp-4],0CCCCCCCCh  
+    // 011B31FB C7 45 FC 00 00 00 00 mov         dword ptr [ebp-4],0  
+    //   return targetFunction();
+    // 011B3202 8B 45 08             mov         eax,dword ptr [ebp+8]  
+    // 011B3205 50                   push        eax  
+    // 011B3206 E8 65 00 00 00       call        targetFunction (011B3270h)  
+    // 011B320B 83 C4 04             add         esp,4  
+    // 011B320E 8B 4D FC             mov         ecx,dword ptr [ebp-4]  
+    // 011B3211 83 C9 01             or          ecx,1  
+    // 011B3214 89 4D FC             mov         dword ptr [ebp-4],ecx  
+    // 011B3217 8B 45 08             mov         eax,dword ptr [ebp+8]  
+    // }
+    // 011B321A 83 C4 04             add         esp,4  
+    // 011B321D 3B EC                cmp         ebp,esp  
+    // 011B321F E8 4C 8F 0C 00       call        _RTC_CheckEsp (0127C170h)  
+    // 011B3224 8B E5                mov         esp,ebp  
+    // 011B3226 5D                   pop         ebp  
+    // 011B3227 C3                   ret  
+    
+    vector<byte> asmCommand;
+
+    // push ebp
+    asmCommand.push_back(0x55);
+
+    // 8B EC                mov         ebp,esp
+    asmCommand.push_back(0x8B);
+    asmCommand.push_back(0xEC);
+
+    if (functionType != FunctionType::GlobalFunction && returnType == FunctionReturnType::ComplexReturnType)
     {
+        // 83 EC 08             sub         esp,8
+        asmCommand.push_back(0x83);
+        asmCommand.push_back(0xEC);
+        asmCommand.push_back(0x08);
+    }
+    else
+    {
+        // 51                   push        ecx
+        asmCommand.push_back(0x51);
     }
 
-    X86WindowsBehaviorChanger::~X86WindowsBehaviorChanger()
+    if (returnType == FunctionReturnType::ComplexReturnType)
     {
-    }
-
-    // returnType: 0 - basic type. 1 - complex type.
-    // functionType: 0 - global function. 1 - class non-virtual method. 2 - class virtual method. 3 - class static member function.
-    void X86WindowsBehaviorChanger::ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM* originalFuncAsm, int functionType, int returnType)
-    {
-        vector<byte> asmCommand;
-
-        // push ebp
-        asmCommand.push_back(0x55);
-
-        // 8B EC                mov         ebp,esp
-        asmCommand.push_back(0x8B);
-        asmCommand.push_back(0xEC);
-
-        if (functionType != 0 && returnType == 1)
-        {
-            // 83 EC 08             sub         esp,8
-            asmCommand.push_back(0x83);
-            asmCommand.push_back(0xEC);
-            asmCommand.push_back(0x08);
-        }
-        else
-        {
-            // 51                   push        ecx  
-            asmCommand.push_back(0x51);
-        }
-
-
-        // C7 45 FC CC CC CC CC mov         dword ptr [this],0CCCCCCCCh
-        /*asmCommand.push_back(0xC7);
-        asmCommand.push_back(0x45);
-        asmCommand.push_back(0xFC);
-        asmCommand.push_back(0xCC);
-        asmCommand.push_back(0xCC);
-        asmCommand.push_back(0xCC);
-        asmCommand.push_back(0xCC);*/
-
-        /*asmCommand.push_back(0x81);
-        asmCommand.push_back(0xEC);
-        asmCommand.push_back(0xCC);
-        asmCommand.push_back(0x00);
-        asmCommand.push_back(0x00);
-        asmCommand.push_back(0x00);
-
-        // push        ebx
-        // push        esi
-        // push        edi
-        asmCommand.push_back(0x53);
-        asmCommand.push_back(0x56);
-        asmCommand.push_back(0x57);
-
-        if (isComplexReturn && isSourceFuncVirtualMethod)
-        {
-        // mov         eax,dword ptr [ebp+8]
+        // 8B 45 08	            mov eax,dword ptr [ebp+8]
         asmCommand.push_back(0x8B);
         asmCommand.push_back(0x45);
         asmCommand.push_back(0x08);
-        }
 
-        // push eax
-        asmCommand.push_back(0x50);*/
-
-        if (returnType == 1)
-        {
-            // 8B 45 08	            mov eax,dword ptr [ebp+8]
-            asmCommand.push_back(0x8B);
-            asmCommand.push_back(0x45);
-            asmCommand.push_back(0x08);
-
-            // 0x50	                push eax
-            asmCommand.push_back(0x50);
-        }
-
-        size_t preparationCodeLength = asmCommand.size();
-
-        // Calculate the offset.
-        // We will inject preparation code to the begining of the source function.
-        // 'E8 <offset>' requires 5 bytes (1 byte for opcode, 4 bytes for address) 
-        // so the next instruction's address is the source function address + preparationCodeLength + 5.
-        // The <offset> value is targetFuncAddress - <next instruction's address>.
-        ULONG64 offset = targetFuncAddress - (sourceFuncAddress + preparationCodeLength + 5);
-
-
-        // call <relative target function address>
-        asmCommand.push_back(0xE8);
-        asmCommand.push_back((offset) & 0xFF);
-        asmCommand.push_back((offset >> 8) & 0xFF);
-        asmCommand.push_back((offset >> 16) & 0xFF);
-        asmCommand.push_back((offset >> 24) & 0xFF);
-
-        if (returnType == 1)
-        {
-            // 83 C4 04				add esp,4
-            asmCommand.push_back(0x83);
-            asmCommand.push_back(0xC4);
-            asmCommand.push_back(0x04);
-
-            if (functionType == 1 || functionType == 2)
-            {
-                // 8B 4D F8             mov         ecx, dword ptr[ebp - 8]
-                asmCommand.push_back(0x8B);
-                asmCommand.push_back(0x4D);
-                asmCommand.push_back(0xF8);
-            }
-            else
-            {
-                // 8B 4D FC             mov         ecx,dword ptr [ebp-4]
-                asmCommand.push_back(0x8B);
-                asmCommand.push_back(0x4D);
-                asmCommand.push_back(0xFC);
-            }
-
-            // 83 C9 01             or          ecx,1
-            asmCommand.push_back(0x83);
-            asmCommand.push_back(0xC9);
-            asmCommand.push_back(0x01);
-
-            if (functionType == 1 || functionType == 2)
-            {
-                // 89 4D F8             mov         dword ptr [ebp-8],ecx
-                asmCommand.push_back(0x89);
-                asmCommand.push_back(0x4D);
-                asmCommand.push_back(0xF8);
-            }
-            else
-            {
-                // 89 4D FC             mov         dword ptr [ebp-4],ecx
-                asmCommand.push_back(0x89);
-                asmCommand.push_back(0x4D);
-                asmCommand.push_back(0xFC);
-            }
-
-            // 8B 45 08             mov         eax,dword ptr [ebp+8]
-            asmCommand.push_back(0x8B);
-            asmCommand.push_back(0x45);
-            asmCommand.push_back(0x08);
-        }
-
-        if (functionType == 1 || functionType == 2)
-        {
-            // 83 C4 08             add         esp,8
-            asmCommand.push_back(0x83);
-            asmCommand.push_back(0xC4);
-            asmCommand.push_back(0x08);
-        }
-        else
-        {
-            // add esp, 4  
-            // because we pushed eax before calling target function address, 
-            // the esp should be pulled back for 4 bytes.
-            asmCommand.push_back(0x83);
-            asmCommand.push_back(0xC4);
-            asmCommand.push_back(0x04);
-        }
-
-        // pop         edi
-        // pop         esi
-        // pop         ebx
-        // add         esp,0CCh
-        // mov         esp,ebp
-        // pop         ebp
-        /*asmCommand.push_back(0x5F);
-        asmCommand.push_back(0x5E);
-        asmCommand.push_back(0x5B);
-        asmCommand.push_back(0x81);
-        asmCommand.push_back(0xC4);
-        asmCommand.push_back(0xCC);
-        asmCommand.push_back(0x00);
-        asmCommand.push_back(0x00);
-        asmCommand.push_back(0x00);
-        asmCommand.push_back(0x8B);
-        asmCommand.push_back(0xE5);
-        asmCommand.push_back(0x5D);*/
-
-        asmCommand.push_back(0x8B);
-        asmCommand.push_back(0xE5);
-        asmCommand.push_back(0x5D);
-
-        // ret
-        if (returnType == 1 && (functionType == 1 || functionType == 2))
-        {
-            asmCommand.push_back(0xC2);
-            asmCommand.push_back(0x04);
-            asmCommand.push_back(0x00);
-        }
-        else
-        {
-            asmCommand.push_back(0xC3);
-        }
-
-        size_t injectedCodeSize = asmCommand.size();
-
-        // First important thing, backup the original asm code.
-        originalFuncAsm->asmCode = new byte[injectedCodeSize];
-        originalFuncAsm->funcAddress = sourceFuncAddress;
-        ReadProcessMemory((HANDLE)-1, (void*)originalFuncAsm->funcAddress, originalFuncAsm->asmCode, injectedCodeSize, 0);
-
-        // Then inject the code to source function.
-        this->DirectWriteToFunction(sourceFuncAddress, &asmCommand[0], injectedCodeSize);
+        // 0x50	                push eax
+        asmCommand.push_back(0x50);
     }
+
+    size_t preparationCodeLength = asmCommand.size();
+
+    // Calculate the offset.
+    // We will inject preparation code to the begining of the source function.
+    // 'E8 <offset>' requires 5 bytes (1 byte for opcode, 4 bytes for address)
+    // so the next instruction's address is the source function address + preparationCodeLength + 5.
+    // The <offset> value is targetFuncAddress - <next instruction's address>.
+    ULONG64 offset = targetFuncAddress - (sourceFuncAddress + preparationCodeLength + 5);
+
+    // call <relative target function address>
+    asmCommand.push_back(0xE8);
+    asmCommand.push_back((offset)&0xFF);
+    asmCommand.push_back((offset >> 8) & 0xFF);
+    asmCommand.push_back((offset >> 16) & 0xFF);
+    asmCommand.push_back((offset >> 24) & 0xFF);
+
+    if (returnType == FunctionReturnType::ComplexReturnType)
+    {
+        // 83 C4 04				add esp,4
+        asmCommand.push_back(0x83);
+        asmCommand.push_back(0xC4);
+        asmCommand.push_back(0x04);
+
+        if (functionType == FunctionType::NonVirtualMemberFunction || functionType == FunctionType::VirtualMemberFunction)
+        {
+            // 8B 4D F8             mov         ecx, dword ptr[ebp - 8]
+            asmCommand.push_back(0x8B);
+            asmCommand.push_back(0x4D);
+            asmCommand.push_back(0xF8);
+        }
+        else
+        {
+            // 8B 4D FC             mov         ecx,dword ptr [ebp-4]
+            asmCommand.push_back(0x8B);
+            asmCommand.push_back(0x4D);
+            asmCommand.push_back(0xFC);
+        }
+
+        // 83 C9 01             or          ecx,1
+        asmCommand.push_back(0x83);
+        asmCommand.push_back(0xC9);
+        asmCommand.push_back(0x01);
+
+        if (functionType == FunctionType::NonVirtualMemberFunction || functionType == FunctionType::VirtualMemberFunction)
+        {
+            // 89 4D F8             mov         dword ptr [ebp-8],ecx
+            asmCommand.push_back(0x89);
+            asmCommand.push_back(0x4D);
+            asmCommand.push_back(0xF8);
+        }
+        else
+        {
+            // 89 4D FC             mov         dword ptr [ebp-4],ecx
+            asmCommand.push_back(0x89);
+            asmCommand.push_back(0x4D);
+            asmCommand.push_back(0xFC);
+        }
+
+        // 8B 45 08             mov         eax,dword ptr [ebp+8]
+        asmCommand.push_back(0x8B);
+        asmCommand.push_back(0x45);
+        asmCommand.push_back(0x08);
+    }
+
+    if (returnType == FunctionReturnType::ComplexReturnType 
+        && (functionType == FunctionType::NonVirtualMemberFunction 
+            || functionType == FunctionType::VirtualMemberFunction))
+    {
+        // 83 C4 08             add         esp,8
+        asmCommand.push_back(0x83);
+        asmCommand.push_back(0xC4);
+        asmCommand.push_back(0x08);
+    }
+    else
+    {
+        // 83 C4 04             add         esp,4 
+        asmCommand.push_back(0x83);
+        asmCommand.push_back(0xC4);
+        asmCommand.push_back(0x04);
+    }
+
+    // 8B E5                mov         esp,ebp
+    asmCommand.push_back(0x8B);
+    asmCommand.push_back(0xE5);
+
+    // 5D                   pop         ebp
+    asmCommand.push_back(0x5D);
+
+    // ret
+    if (returnType == FunctionReturnType::ComplexReturnType 
+        && (functionType == FunctionType::NonVirtualMemberFunction 
+            || functionType == FunctionType::VirtualMemberFunction))
+    {
+        // C2 04 00             ret         4
+        asmCommand.push_back(0xC2);
+        asmCommand.push_back(0x04);
+        asmCommand.push_back(0x00);
+    }
+    else
+    {
+        // C3                   ret
+        asmCommand.push_back(0xC3);
+    }
+
+    size_t injectedCodeSize = asmCommand.size();
+
+    // First important thing, backup the original asm code.
+    originalFuncAsm->asmCode = new byte[injectedCodeSize];
+    originalFuncAsm->funcAddress = sourceFuncAddress;
+    ReadProcessMemory((HANDLE)-1, (void *)originalFuncAsm->funcAddress, originalFuncAsm->asmCode, injectedCodeSize, 0);
+
+    // Then inject the code to source function.
+    this->DirectWriteToFunction(sourceFuncAddress, &asmCommand[0], injectedCodeSize);
+}
 }

--- a/src/windows/src/x86windowsbehaviorchanger.cpp
+++ b/src/windows/src/x86windowsbehaviorchanger.cpp
@@ -14,7 +14,7 @@ X86WindowsBehaviorChanger::~X86WindowsBehaviorChanger()
 {
 }
 
-void X86WindowsBehaviorChanger::ReplaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM *originalFuncAsm, FunctionType functionType, FunctionReturnType returnType)
+void X86WindowsBehaviorChanger::replaceFunction(ULONG64 sourceFuncAddress, ULONG64 targetFuncAddress, OriginalFuncASM *originalFuncAsm, FunctionType functionType, FunctionReturnType returnType)
 {
     // The idea is hijack the original function, inject op codes to let it 
     // jump to the target function.
@@ -238,6 +238,6 @@ void X86WindowsBehaviorChanger::ReplaceFunction(ULONG64 sourceFuncAddress, ULONG
     ReadProcessMemory((HANDLE)-1, (void *)originalFuncAsm->funcAddress, originalFuncAsm->asmCode, injectedCodeSize, 0);
 
     // Then inject the code to source function.
-    this->DirectWriteToFunction(sourceFuncAddress, &asmCommand[0], injectedCodeSize);
+    this->directWriteToFunction(sourceFuncAddress, &asmCommand[0], injectedCodeSize);
 }
 }

--- a/tests/fakeclassnonvirtualmethodtest.cpp
+++ b/tests/fakeclassnonvirtualmethodtest.cpp
@@ -7,28 +7,28 @@
 class FakeClassNonVirtualMethodTestFixture : public ::testing::Test
 {
 public:
-    int FakeFunc()
+    int fakeFunc()
     {
         return 6;
     }
 
-    std::string FakeStringFunc()
+    std::string fakeStringFunc()
     {
         return "Fake string func";
     }
 
-    std::string* FakeStringPointerFunc()
+    std::string* fakeStringPointerFunc()
     {
         std::string* p = new std::string("Fake string pointer");
 
         return p;
     }
 
-    Address FakeGetAnAddress()
+    Address fakeGetAnAddress()
     {
         Address addr;
-        addr.SetAddressLine("fakeAddressLine");
-        addr.SetZipCode("fakeZipCode");
+        addr.setAddressLine("fakeAddressLine");
+        addr.setZipCode("fakeZipCode");
 
         return addr;
     }
@@ -43,19 +43,14 @@ protected:
     }
 };
 
-std::string FooReturnString()
+std::string fooReturnString()
 {
     return "FooReturnString";
 }
 
-std::string FakeFooReturnString()
+std::string fakeFooReturnString()
 {
     return "FakeFooReturnString";
-}
-
-std::string ddd()
-{
-	return FakeFooReturnString();
 }
 
 TEST_F(FakeClassNonVirtualMethodTestFixture, FakeIntFunctionWhenCalled)
@@ -64,13 +59,13 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeIntFunctionWhenCalled)
     int expected = 6;
     InjectorPP::Injector injector;
 
-    injector.WhenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::GetAnInteger))
-        .WillExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::FakeFunc));
+    injector.whenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::getAnInteger))
+        .willExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::fakeFunc));
 
     BaseClassTest b = BaseClassTest();
 
     // Act
-    int actual = b.GetAnInteger();
+    int actual = b.getAnInteger();
 
     // Assert
     EXPECT_EQ(expected, actual);
@@ -82,13 +77,13 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeStringPointerFunctionWhenCalled
     std::string expected = "Fake string pointer";
     InjectorPP::Injector injector;
     
-    injector.WhenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::GetAStringPointer))
-        .WillExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::FakeStringPointerFunc));
+    injector.whenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::getAStringPointer))
+        .willExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::fakeStringPointerFunc));
 
     BaseClassTest b = BaseClassTest();
 
     // Act
-    std::string* actual = b.GetAStringPointer();
+    std::string* actual = b.getAStringPointer();
 
     // Assert
     EXPECT_EQ(expected, *actual);
@@ -103,11 +98,11 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeGlobalStringFunctionWhenCalled)
     std::string expected = "FakeFooReturnString";
     InjectorPP::Injector injector;
 
-    injector.WhenCalled(FooReturnString)
-        .WillExecute(FakeFooReturnString);
+    injector.whenCalled(fooReturnString)
+        .willExecute(fakeFooReturnString);
 
     // Act
-    std::string actual = FooReturnString();
+    std::string actual = fooReturnString();
 
     // Assert
     EXPECT_EQ(expected, actual);
@@ -116,19 +111,19 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeGlobalStringFunctionWhenCalled)
 TEST_F(FakeClassNonVirtualMethodTestFixture, FakeStringFunctionWhenCalled)
 {
 	BaseClassTest b1;
-	std::string aa = b1.GetAString();
+	std::string aa = b1.getAString();
 
     // Prepare
     std::string expected = "Fake string func";
     InjectorPP::Injector injector;
 
-    injector.WhenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::GetAString))
-        .WillExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::FakeStringFunc));
+    injector.whenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::getAString))
+        .willExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::fakeStringFunc));
 
     BaseClassTest b;
 
     // Act
-    std::string actual = b.GetAString();
+    std::string actual = b.getAString();
 
     // Assert
     EXPECT_EQ(expected, actual);
@@ -139,18 +134,18 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeFunctionReturnUserDefinedClassW
 {
     // Prepare
     Address expected;
-    expected.SetAddressLine("fakeAddressLine");
-    expected.SetZipCode("fakeZipCode");
+    expected.setAddressLine("fakeAddressLine");
+    expected.setZipCode("fakeZipCode");
 
     InjectorPP::Injector injector;
 
-    injector.WhenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::GetAnAddress))
-        .WillExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::FakeGetAnAddress));
+    injector.whenCalled(INJECTORPP_MEMBER_FUNCTION(BaseClassTest::getAnAddress))
+        .willExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::fakeGetAnAddress));
 
     BaseClassTest b;
 
     // Act
-    Address actual = b.GetAnAddress();
+    Address actual = b.getAnAddress();
 
     // Assert
     EXPECT_EQ(expected, actual);
@@ -160,16 +155,16 @@ TEST_F(FakeClassNonVirtualMethodTestFixture, FakeStaticFunctionReturnUserDefined
 {
     // Prepare
     Address expected;
-    expected.SetAddressLine("fakeAddressLine");
-    expected.SetZipCode("fakeZipCode");
+    expected.setAddressLine("fakeAddressLine");
+    expected.setZipCode("fakeZipCode");
 
     InjectorPP::Injector injector;
 
-    injector.WhenCalled(INJECTORPP_STATIC_MEMBER_FUNCTION(BaseClassTest::GetAnAddressStatic))
-        .WillExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::FakeGetAnAddress));
+    injector.whenCalled(INJECTORPP_STATIC_MEMBER_FUNCTION(BaseClassTest::getAnAddressStatic))
+        .willExecute(INJECTORPP_MEMBER_FUNCTION(FakeClassNonVirtualMethodTestFixture::fakeGetAnAddress));
 
     // Act
-    Address actual = BaseClassTest::GetAnAddressStatic();
+    Address actual = BaseClassTest::getAnAddressStatic();
 
     // Assert
     EXPECT_EQ(expected, actual);

--- a/tests/fakeclassvirtualmethodtest.cpp
+++ b/tests/fakeclassvirtualmethodtest.cpp
@@ -16,17 +16,17 @@ protected:
     }
 };
 
-int FakeIntFuncForDerived()
+int fakeIntFuncForDerived()
 {
     return 2;
 }
 
-int FakeIntFuncForBase()
+int fakeIntFuncForBase()
 {
     return 6;
 }
 
-std::string FakeStringFuncForBase()
+std::string fakeStringFuncForBase()
 {
     return "Faked base string";
 }
@@ -38,11 +38,11 @@ TEST_F(FakeClassVirtualMethodTestFixture, MockBaseClassVirtualMemberFunctionWhen
     BaseClassTest* base = new BaseClassTest();
 
     InjectorPP::Injector injector;
-    injector.WhenCalledVirtualMethod(base, "GetAnIntegerVirtual")
-        .WillExecute(FakeIntFuncForBase);
+    injector.whenCalledVirtualMethod(base, "getAnIntegerVirtual")
+        .willExecute(fakeIntFuncForBase);
 
     // Act
-    int actual = base->GetAnIntegerVirtual();
+    int actual = base->getAnIntegerVirtual();
 
     // Assert
     EXPECT_EQ(expected, actual);
@@ -58,11 +58,11 @@ TEST_F(FakeClassVirtualMethodTestFixture, MockDerivedClassVirtualMemberFunctionW
     BaseClassTest* derived = new SubClassTest();
 
     InjectorPP::Injector injector;
-    injector.WhenCalledVirtualMethod(derived, "GetAnIntegerVirtual")
-        .WillExecute(FakeIntFuncForDerived);
+    injector.whenCalledVirtualMethod(derived, "getAnIntegerVirtual")
+        .willExecute(fakeIntFuncForDerived);
 
     // Act
-    int actual = derived->GetAnIntegerVirtual();
+    int actual = derived->getAnIntegerVirtual();
 
     // Assert
     EXPECT_EQ(expected, actual);
@@ -75,16 +75,14 @@ TEST_F(FakeClassVirtualMethodTestFixture, MockBaseClassVirtualMemberFunctionRetu
 {
     // Prepare
     std::string expected = "Faked base string";
-    BaseClassTest* base = new BaseClassTest();
-
-    std::string a1 = base->GetStringVirtual();
+    BaseClassTest* base = new BaseClassTest();    
 
     InjectorPP::Injector injector;
-    injector.WhenCalledVirtualMethod(base, "GetStringVirtual")
-        .WillExecute(FakeStringFuncForBase);
+    injector.whenCalledVirtualMethod(base, "getStringVirtual")
+        .willExecute(fakeStringFuncForBase);
 
     // Act
-    std::string actual = base->GetStringVirtual();
+    std::string actual = base->getStringVirtual();
 
     // Assert
     EXPECT_EQ(expected, actual);

--- a/tests/fixtures/address.cpp
+++ b/tests/fixtures/address.cpp
@@ -5,23 +5,23 @@
 
 using std::string;
 
-std::string Address::GetZipCode()
+std::string Address::getZipCode()
 {
-    return this->zipCode;
+    return this->m_zipCode;
 }
 
-void Address::SetZipCode(const std::string& zipCode)
+void Address::setZipCode(const std::string& zipCode)
 {
-    this->zipCode = zipCode;
+    this->m_zipCode = zipCode;
 }
 
-std::string Address::GetAddressLine()
+std::string Address::getAddressLine()
 {
-    return this->addressLine;
+    return this->m_addressLine;
 }
 
-void Address::SetAddressLine(const std::string& addressLine)
+void Address::setAddressLine(const std::string& addressLine)
 {
-    this->addressLine = addressLine;
+    this->m_addressLine = addressLine;
 }
 

--- a/tests/fixtures/address.h
+++ b/tests/fixtures/address.h
@@ -14,32 +14,32 @@ public:
 
     Address(const Address& rhs)
     {
-        this->zipCode = rhs.zipCode;
-        this->addressLine = rhs.addressLine;
+        this->m_zipCode = rhs.m_zipCode;
+        this->m_addressLine = rhs.m_addressLine;
     }
 
     Address& operator=(Address rhs)
     {
-        this->zipCode = rhs.zipCode;
-        this->addressLine = rhs.addressLine;
+        this->m_zipCode = rhs.m_zipCode;
+        this->m_addressLine = rhs.m_addressLine;
 
         return *this;
     }
 
     bool operator==(const Address& rhs) const
     {
-        return this->zipCode == rhs.zipCode && this->addressLine == rhs.addressLine;
+        return this->m_zipCode == rhs.m_zipCode && this->m_addressLine == rhs.m_addressLine;
     }
 
-    std::string GetZipCode();
-    void SetZipCode(const std::string& zipCode);
+    std::string getZipCode();
+    void setZipCode(const std::string& zipCode);
 
-    std::string GetAddressLine();
-    void SetAddressLine(const std::string& addressLine);
+    std::string getAddressLine();
+    void setAddressLine(const std::string& addressLine);
 
 private:
-    std::string zipCode;
-    std::string addressLine;
+    std::string m_zipCode;
+    std::string m_addressLine;
 };
 
 #endif

--- a/tests/fixtures/baseclasstest.cpp
+++ b/tests/fixtures/baseclasstest.cpp
@@ -8,17 +8,17 @@ BaseClassTest::~BaseClassTest()
 {
 }
 
-int BaseClassTest::GetAnIntegerVirtual()
+int BaseClassTest::getAnIntegerVirtual()
 {
     return 0;
 }
 
-std::string BaseClassTest::GetStringVirtual()
+std::string BaseClassTest::getStringVirtual()
 {
     return "Normal base string";
 }
 
-int BaseClassTest::GetAnInteger()
+int BaseClassTest::getAnInteger()
 {
 	return -1;
 }
@@ -28,32 +28,32 @@ std::string fakefunc()
 	return "fake";
 }
 
-std::string BaseClassTest::GetAString()
+std::string BaseClassTest::getAString()
 {
 	return fakefunc();
 }
 
-std::string* BaseClassTest::GetAStringPointer()
+std::string* BaseClassTest::getAStringPointer()
 {
     std::string* p = new std::string("Normal string pointer.");
 
     return p;
 }
 
-Address BaseClassTest::GetAnAddress()
+Address BaseClassTest::getAnAddress()
 {
     Address addr;
-    addr.SetAddressLine("normalAddressLine");
-    addr.SetZipCode("normalZipCode");
+    addr.setAddressLine("normalAddressLine");
+    addr.setZipCode("normalZipCode");
 
     return addr;
 }
 
-Address BaseClassTest::GetAnAddressStatic()
+Address BaseClassTest::getAnAddressStatic()
 {
     Address addr;
-    addr.SetAddressLine("normalAddressLine");
-    addr.SetZipCode("normalZipCode");
+    addr.setAddressLine("normalAddressLine");
+    addr.setZipCode("normalZipCode");
 
     return addr;
 }

--- a/tests/fixtures/baseclasstest.h
+++ b/tests/fixtures/baseclasstest.h
@@ -11,19 +11,19 @@ public:
 
     virtual ~BaseClassTest();
 
-    virtual int GetAnIntegerVirtual();
+    virtual int getAnIntegerVirtual();
 
-    virtual std::string GetStringVirtual();
+    virtual std::string getStringVirtual();
 
-    int GetAnInteger();
+    int getAnInteger();
 
-    std::string GetAString();
+    std::string getAString();
 
-    std::string* GetAStringPointer();
+    std::string* getAStringPointer();
 
-    Address GetAnAddress();
+    Address getAnAddress();
 
-    static Address GetAnAddressStatic();
+    static Address getAnAddressStatic();
 };
 
 #endif

--- a/tests/fixtures/subclasstest.cpp
+++ b/tests/fixtures/subclasstest.cpp
@@ -8,12 +8,12 @@ SubClassTest::~SubClassTest()
 {
 }
 
-int SubClassTest::GetAnIntegerVirtual()
+int SubClassTest::getAnIntegerVirtual()
 {
     return 1;
 }
 
-std::string SubClassTest::GetStringVirtual()
+std::string SubClassTest::getStringVirtual()
 {
     return "Normal sub string";
 }

--- a/tests/fixtures/subclasstest.h
+++ b/tests/fixtures/subclasstest.h
@@ -9,8 +9,8 @@ public:
     SubClassTest();
     virtual ~SubClassTest();
 
-    virtual int GetAnIntegerVirtual();
-    virtual std::string GetStringVirtual();
+    virtual int getAnIntegerVirtual();
+    virtual std::string getStringVirtual();
 };
 
 #endif


### PR DESCRIPTION
- Use enums instead of raw int to represent function type and function return type.
- Add more comments in the magic `ReplaceFunction` function.
- Updated `build.cmd` to reflect build error.

Fix #18